### PR TITLE
Fix horsepower weight

### DIFF
--- a/core/src/units/builtin.rs
+++ b/core/src/units/builtin.rs
@@ -307,7 +307,7 @@ const COMMON_SI_DERIVED_UNITS: &[UnitTuple] = &[
 	(
 		"horsepower",
 		"horsepowers",
-		"l@745.699987158227022 watts",
+		"l@745.69987158227022 watts",
 		"",
 	),
 	("hp", "", "s@horsepower", ""),


### PR DESCRIPTION
The horsepower/watt conversion was off by a bit. Should be two 9s, not 3.

Places I used to verify this:
- https://en.wikipedia.org/wiki/Horsepower#Mechanical_horsepower
- https://www.kwtohp.net/hp-to-watts-conversion
- https://www.inchcalculator.com/convert/horsepower-to-watt
- https://www.rapidtables.com/convert/power/hp-to-watt.html